### PR TITLE
Add support for a configurable session directory

### DIFF
--- a/tmuxstart
+++ b/tmuxstart
@@ -19,11 +19,12 @@ usage() {
 [ $# -ne 1 ] && usage && exit 1
 
 session=$1
+sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
 TMUX_OLD=$TMUX
 TMUX=
 if ! tmux has-session -t $session ; then
-    if [ -f ~/.tmuxstart/$1 ] ; then
-        . ~/.tmuxstart/$1
+    if [ -f "$sessiondir/$1" ] ; then
+        . "$sessiondir/$1"
     else
         tmux new-session -d -s $session
     fi


### PR DESCRIPTION
I thought it could be useful to allow a user to override the default session directory by exporting TMUXSTART_DIR in their shell.

Also, thanks for sharing this. I really appreciate the simplicity of this approach for persistent tmux sessions.
