### PR TITLE
Remove -c option from new_window()

### DIFF
--- a/tmuxstart
+++ b/tmuxstart
@@ -7,7 +7,7 @@ new_session() {
     tmux new-session -d -s $session "$@"
     [ "$path" ] && set_path "$path"
 }
-new_window() { tmux new-window -d -c $PWD -t $session "$@"; }
+new_window() { tmux new-window -d -t $session "$@"; }
 kill_window() { tmux kill-window -t $session:"$@"; }
 select_pane() { tmux select-pane -t $session:"$@"; }
 select_window() { tmux select-window -t $session:"$@"; }


### PR DESCRIPTION
"-c" option is not supported in tmux 1.6

Not sure whether this will cause unexpected problem. So far new-window always creates a new window from $PWD for me.

Supporting tmux 1.6 would be nice, since it is the version on the latest RHEL.
