### PR TITLE
Add basic tab completion under bash and zsh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,38 @@ List all available session files.
 
 Print tmuxstart version number.
 
+CLI tab completion
+-------------------
+
+Currently there's only zsh and bash basic support for tab completions.
+
+To enable tab completion for tmuxstart in ZSH, add the tmuxstart completion file
+to a directory in your ``fpath``:
+
+    ``$ mkdir -p ~/.zsh/completions``
+    ``cp completions/_tmuxstart.zsh ~/.zsh/completions/_tmuxstart``
+
+Add the following to your .zshrc file to ensure tab completion is enabled and
+the ``~/.zsh/completions`` directory is added to your ``fpath``
+
+    ``$ autoload -U compinit``
+
+    ``$ compinit``
+
+    ``fpath=(~/.zsh/completion $fpath)``
+
+If you're doing this by hand you'll probably want to execute this too:
+
+    ``$ zstyle ':completion:*:descriptions' format '%U%B%d%b%u'``
+
+    ``$ zstyle ':completion:*:warnings' format '%BSorry, no matches for: %d%b'``
+
+
+In bash it should work by sourcing the file directly
+For example you could have a line lik this in yout bashrc:
+
+    ``source "path_to_tmuxstart_completions/tmuxstart.bash"``
+
 Contributing & Help
 -------------------
 

--- a/completions/_tmuxstart.bash
+++ b/completions/_tmuxstart.bash
@@ -1,0 +1,20 @@
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for tmuxstart under bash (https://github.com/treyhunner/tmuxstart).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Farfanoide (https://github.com/farfanoide)
+#
+# ------------------------------------------------------------------------------
+
+_tmuxstart()
+{
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    COMPREPLY=( $(compgen -W "$(\ls ${TMUXSTART_DIR:-$HOME/.tmuxstart})" -- $cur) )
+}
+complete -F _tmuxstart tmuxstart

--- a/completions/_tmuxstart.zsh
+++ b/completions/_tmuxstart.zsh
@@ -1,0 +1,21 @@
+#compdef tmuxstart
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for tmuxstart under zsh (https://github.com/treyhunner/tmuxstart).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Farfanoide (https://github.com/farfanoide)
+#
+# ------------------------------------------------------------------------------
+local sessions
+
+sessions=($(\ls ${TMUXSTART_DIR:-$HOME/.tmuxstart}))
+
+_arguments -s \
+    '*:Start/Attach session:($sessions)'
+


### PR DESCRIPTION
basic tab completion.
by hitting tab one gets a list of session files under $TMUXSTART_DIR or if not set, ~/.tmuxstart
tested in zsh 5.0.5 and bash 3.2.51/4.3.18
