### PR TITLE
adds arguments parsing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ the same arguments as ``tmux new-window``.  Examples::
 
     new_window  # Just create a new window
     new_window -n edit emacs  # Create a new window named "edit" running emacs
-    
+
 rename
 ~~~~~~
 ``rename`` renames an existing window.  This function accepts the same arguments
@@ -64,7 +64,7 @@ function accepts the same arguments as ``tmux send-keys``.  Examples::
 
     send_keys 1 "echo hello" "Enter"  # Run "echo hello" in window 1
     send_keys 2 C-c  # Send Ctrl-C key combination to window 2
-    
+
 send_line
 ~~~~~~~~~
 ``send_line`` sends a line of input to a given window number in the session.
@@ -171,6 +171,24 @@ management::
     # Select pane 1 in window 2
     select_pane 2.1
 
+
+CLI usage
+---------------------
+
+Arguments
+    ``$ tmuxstart session_name``
+
+Will search for a session file called "session_name" in ``$TMUXSTART_DIR`` if
+set, otherwise in ``~/.tmuxstart`` and load it.  If no such file is found, it
+will start a new ``tmux`` session named "session_name".
+
+    ``$ tmuxstart -h``
+
+Show help dialog.
+
+    ``$ tmuxstart -l``
+
+List all available session files.
 
 Contributing & Help
 -------------------

--- a/tmuxstart
+++ b/tmuxstart
@@ -21,7 +21,7 @@ usage() {
 while getopts ':hl' option; do
     case "${option}" in
         h)
-            usage ;;
+            usage ; exit 0 ;;
         l)
             \ls  $sessiondir ; exit 0 ;;
         *)

--- a/tmuxstart
+++ b/tmuxstart
@@ -6,11 +6,11 @@ sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
 usage() {
     local ts_name
     ts_name=$(basename $0)
-    echo "${ts_name} options:"
-    echo "=================="
-    echo "${ts_name} tmux-session   -- Start/Attach session";
-    echo "${ts_name} -h             -- Print help menu"
-    echo "${ts_name} -l             -- List all available session files"
+    echo "Usage: ${ts_name} [OPTIONS] SESSION\n"
+    echo "Launch reusable configurations for named tmux sessions.\n"
+    echo "Options:\n"
+    echo "-h Print help menu"
+    echo "-l List all available session files"
 }
 
 [ $# -lt 1 ] && usage && exit 1
@@ -26,7 +26,7 @@ while getopts ':hl' option; do
             \ls  $sessiondir ; exit 0 ;;
         *)
             echo "Invalid option"
-            usage
+            usage ; exit 1
             ;;
     esac
 done

--- a/tmuxstart
+++ b/tmuxstart
@@ -1,5 +1,36 @@
 #!/bin/sh
 
+sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
+
+# Print usage information if there's not enough arguments
+usage() {
+    local ts_name
+    ts_name=$(basename $0)
+    echo "${ts_name} options:"
+    echo "=================="
+    echo "${ts_name} tmux-session   -- Start/Attach session";
+    echo "${ts_name} -h             -- Print help menu"
+    echo "${ts_name} -l             -- List all available session files"
+}
+
+[ $# -lt 1 ] && usage && exit 1
+
+# local functions
+
+# arguments parsing loop
+while getopts ':hl' option; do
+    case "${option}" in
+        h)
+            usage ;;
+        l)
+            \ls  $sessiondir ; exit 0 ;;
+        *)
+            echo "Invalid option"
+            usage
+            ;;
+    esac
+done
+
 # Some helper functions for simpler session files
 new_session() {
     # Set default path based on $path variable if defined
@@ -20,13 +51,7 @@ set_path() { tmux set-option -t $session default-path "$@"; }
 split() { tmux split-window -t $session:"$@"; }
 swap() { tmux swap-pane -t $session:"$@"; }
 
-
-# Print usage information if there's not exactly 1 argument
-usage() { echo "Usage: $0 tmux-session"; }
-[ $# -ne 1 ] && usage && exit 1
-
 session=$1
-sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
 TMUX_OLD=$TMUX
 TMUX=
 if ! tmux has-session -t $session ; then


### PR DESCRIPTION
adds main loop for parsing arguments; current supported arguments are:
-h -- Show help dialog.
-l -- List all available session files.

Implemented whith a while loop and parsed with the sh/bash builtin
'getopts' which gives the possibility of chainning arguments together
like so:
    `tmuxstart -hl`
or:
    `tmuxstart -h -l`
