### PR TITLE
Adds hability to have local/global session files

### DIFF
--- a/tmuxstart
+++ b/tmuxstart
@@ -26,14 +26,19 @@ usage() { echo "Usage: $0 tmux-session"; }
 [ $# -ne 1 ] && usage && exit 1
 
 session=$1
-sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
 TMUX_OLD=$TMUX
 TMUX=
 if ! tmux has-session -t $session ; then
-    if [ -f "$sessiondir/$1" ] ; then
-        . "$sessiondir/$1"
+    if [ -f "./$session" ]; then
+        . "./$session"
     else
-        tmux new-session -d -s $session
+        if [ -f "$sessiondir/$session" ] ; then
+            cd $sessiondir
+            [ -h "./$session" ] && cd $(dirname $(readlink "$session"))
+            . "./$session"
+        else
+            tmux new-session -d -s $session
+        fi
     fi
 fi
 if [ "$TMUX_OLD" = "" ]; then


### PR DESCRIPTION
This is a first draft of what local sessions could look like.
They could be distributed with projects and version
controlled. They could load up entire project's environment
regardless of the machine in which they are being loaded.

Loading of sessions now has priority, tmuxstart will now search
firstly on the current folder for a session file, if not found, it'll
keep searching as it used to. if no session file is found neither
locally, nor in $TMUXSTART_DIR, it'll create a new session as it always
did.
Local sessions could also be accessed globally in order to keep working
projects at hand.

This first implementation considers all symlinks in $TMUXSTART_DIR as
local sessions. Before loading a local session, tmxustart wil cd into
its directory.
this could go hand in hand with a -c argument
(see https://github.com/treyhunner/tmuxstart/pull/11) which would
symlink the local session file to make it available globally.

I believe this could be done even more wisely by dividing
$TMUXSTART_DIR into 3 folders, one for global sessions, one for the
local ones, and one for examples, but i leave that up for discussion.

Some considerations here would be if session files should have
extensions. this would help when loading or symlinking them.
