### PR TITLE
Add -o option to open session files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,11 @@ Show help dialog.
 
 List all available session files.
 
+    ``$ tmuxstart -o session_name``
+
+Open session file with given name for editing. If no session file is found,
+creates one with example content.
+
 Contributing & Help
 -------------------
 

--- a/tmuxstart
+++ b/tmuxstart
@@ -13,6 +13,7 @@ _usage() {
     echo "Options:\n"
     echo "-h Print help menu"
     echo "-l List all available session files"
+    echo "-o Open/Create session file for editing"
 }
 
 [ $# -lt 1 ] && _usage && exit 1

--- a/tmuxstart
+++ b/tmuxstart
@@ -2,8 +2,10 @@
 
 sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
 
-# Print usage information if there's not enough arguments
-usage() {
+# local functions
+
+# Print _usage information if there's not enough arguments
+_usage() {
     local ts_name
     ts_name=$(basename $0)
     echo "Usage: ${ts_name} [OPTIONS] SESSION\n"
@@ -13,21 +15,52 @@ usage() {
     echo "-l List all available session files"
 }
 
-[ $# -lt 1 ] && usage && exit 1
+[ $# -lt 1 ] && _usage && exit 1
 
-# local functions
+_open_session_file() {
+    local session_file session_example
+    # TODO: add option to select example file
+    session_example="
+    # Make an htop window make a regular shell window\n
+    new_session -n htop htop\n
+    new_window\n
+    "
+    session_file="${sessiondir}/${OPTARG}"
+
+    if [ ! -f $session_file ]; then
+        # EDITOR not explicitly set or uses vim
+        if [ -z "$EDITOR" -o "$EDITOR" = 'vi' -o "$EDITOR" = 'vim' ]; then
+            # create a buffer with dummy content in $TMUXSTART_DIR
+            echo "${session_example}" | ${EDITOR:-vi} - +"file ${session_file}"
+        else
+            echo "${session_example}" > $session_file;
+            $EDITOR $session_file
+        fi
+    else
+        ${EDITOR:-vi} $session_file
+    fi
+}
+
+_list_session_files(){
+    \ls  $sessiondir ; exit 0
+}
 
 # arguments parsing loop
-while getopts ':hl' option; do
+while getopts ':hlo:' option; do
     case "${option}" in
         h)
-            usage ; exit 0 ;;
+            _usage ; exit 0 ;;
         l)
-            \ls  $sessiondir ; exit 0 ;;
+            _list_session_files ;;
+        o)
+            _open_session_file
+            exit 0 ;;
+        :)
+            echo "Option -$OPTARG requires an argument."
+            _usage ; exit 1 ;;
         *)
             echo "Invalid option"
-            usage ; exit 1
-            ;;
+            _usage ; exit 1 ;;
     esac
 done
 

--- a/tmuxstart
+++ b/tmuxstart
@@ -2,32 +2,66 @@
 
 sessiondir=${TMUXSTART_DIR:-$HOME/.tmuxstart}
 
-# Print usage information if there's not enough arguments
-usage() {
+# local functions
+
+# Print _usage information if there's not enough arguments
+_usage() {
     local ts_name
     ts_name=$(basename $0)
     echo "${ts_name} options:"
     echo "=================="
-    echo "${ts_name} tmux-session   -- Start/Attach session";
-    echo "${ts_name} -h             -- Print help menu"
-    echo "${ts_name} -l             -- List all available session files"
+    echo "${ts_name} tmux-session    -- Start/Attach session";
+    echo "${ts_name} -h              -- Print help menu"
+    echo "${ts_name} -l              -- List all available session files"
+    echo "${ts_name} -o session_name -- Edit/Create session file "
 }
 
-[ $# -lt 1 ] && usage && exit 1
+[ $# -lt 1 ] && _usage && exit 1
 
-# local functions
+_open_session_file() {
+    local session_file session_example
+    # TODO: add option to select example file
+    session_example="
+    # Make an htop window make a regular shell window\n
+    new_session -n htop htop\n
+    new_window\n
+    "
+    session_file="${sessiondir}/${OPTARG}"
+
+    if [ ! -f $session_file ]; then
+        # EDITOR not explicitly set or uses vim
+        if [ -z "$EDITOR" -o "$EDITOR" = 'vi' -o "$EDITOR" = 'vim' ]; then
+            # create a buffer with dummy content in $TMUXSTART_DIR
+            echo "${session_example}" | ${EDITOR:-vi} - +"file ${session_file}"
+        else
+            echo "${session_example}" > $session_file;
+            $EDITOR $session_file
+        fi
+    else
+        ${EDITOR:-vi} $session_file
+    fi
+}
+
+_list_session_files(){
+    \ls  $sessiondir ; exit 0
+}
 
 # arguments parsing loop
-while getopts ':hl' option; do
+while getopts ':hlo:' option; do
     case "${option}" in
         h)
-            usage ; exit 0 ;;
+            _usage ; exit 0 ;;
         l)
-            \ls  $sessiondir ; exit 0 ;;
+            _list_session_files ;;
+        o)
+            _open_session_file
+            exit 0 ;;
+        :)
+            echo "Option -$OPTARG requires an argument."
+            _usage ; exit 1 ;;
         *)
             echo "Invalid option"
-            usage
-            ;;
+            _usage ; exit 1 ;;
     esac
 done
 


### PR DESCRIPTION
Open/Create option:
Discussion should arise here on wether one option should only edit or
both edit/create session files. one could also have a -n(new) option.

Note on example files: having an examples folder available would greatly
help when creating new sessions, -n option could receive an
example_session_name which would copy said template in order to rapidly
get new projects up and running.
examples could be under $TMUXSTART_DIR/examples as stated in https://github.com/treyhunner/tmuxstart/pull/12

This commit also: 
- Moves code from inside the main loop to local functions to keep things
  more organized.
- Renames usage function to _usage to be consistent with other local
  funcitons and updates it's output
